### PR TITLE
feat(core): manual initialization

### DIFF
--- a/Wortal/aces.json
+++ b/Wortal/aces.json
@@ -977,6 +977,18 @@
 	"wortal": {
 		"conditions": [
             {
+                "id": "initialize-callback",
+                "scriptName": "InitializeCallback",
+                "highlight": true,
+                "isTrigger": true
+            },
+            {
+                "id": "start-game-callback",
+                "scriptName": "StartGameCallback",
+                "highlight": true,
+                "isTrigger": true
+            },
+            {
                 "id": "error-callback",
                 "scriptName": "ErrorCallback",
                 "highlight": true,
@@ -1097,6 +1109,16 @@
                 ]
             },
             {
+                "id": "initialize-async",
+                "scriptName": "InitializeAsync",
+                "highlight": true
+            },
+            {
+                "id": "start-game-async",
+                "scriptName": "StartGameAsync",
+                "highlight": true
+            },
+            {
                 "id": "set-loading-progress",
                 "scriptName": "SetLoadingProgress",
                 "highlight": true,
@@ -1116,6 +1138,11 @@
             }
         ],
 		"expressions": [
+            {
+                "id": "initialized",
+                "expressionName": "Initialized",
+                "returnType": "number"
+            },
             {
                 "id": "error-status",
                 "expressionName": "ErrorStatus",

--- a/Wortal/c3runtime/actions.js
+++ b/Wortal/c3runtime/actions.js
@@ -350,6 +350,14 @@ self.C3.Plugins.wortal.Acts =
     ////////////////////////////////////////////
     // SDK API
     ////////////////////////////////////////////
+    InitializeAsync() {
+        this.WortalSDK('initialize', {});
+    },
+
+    StartGameAsync() {
+        this.WortalSDK('start_game', {});
+    },
+
     SetLoadingProgress(value) {
         this.WortalSDK('set_loading_progress', {
             value: value

--- a/Wortal/c3runtime/conditions.js
+++ b/Wortal/c3runtime/conditions.js
@@ -219,6 +219,14 @@ self.C3.Plugins.wortal.Cnds =
     ////////////////////////////////////////////
     // SDK API
     ////////////////////////////////////////////
+    InitializeCallback() {
+        return true;
+    },
+
+    StartGameCallback() {
+        return true;
+    },
+
     ErrorCallback() {
         return true;
     },

--- a/Wortal/c3runtime/expressions.js
+++ b/Wortal/c3runtime/expressions.js
@@ -187,6 +187,10 @@ self.C3.Plugins.wortal.Exps =
     ////////////////////////////////////////////
     // SDK API
     ////////////////////////////////////////////
+    Initialized() {
+        return this._isInitialized ? 1 : 0;
+    },
+
     ErrorStatus() {
         return this._errorStatus;
     },

--- a/Wortal/c3runtime/instance.js
+++ b/Wortal/c3runtime/instance.js
@@ -9,6 +9,7 @@ C3.Plugins.wortal.Instance = class WortalInstance extends C3.SDKInstanceBase
 		super(inst, DOM_COMPONENT_ID);
 
         // SDK properties
+        this._isInitialized = false;
         this._errorStatus = "";
         this._supportedAPIs = "";
 
@@ -364,6 +365,15 @@ C3.Plugins.wortal.Instance = class WortalInstance extends C3.SDKInstanceBase
         ////////////////////////////////////////////
         // SDK API
         ////////////////////////////////////////////
+        this.AddDOMMessageHandler("initialize_callback", () => {
+            this._isInitialized = true;
+            this.Trigger(C3.Plugins.wortal.Cnds.InitializeCallback);
+        });
+
+        this.AddDOMMessageHandler("start_game_callback", () => {
+            this.Trigger(C3.Plugins.wortal.Cnds.StartGameCallback);
+        });
+
         this.AddDOMMessageHandler("error_callback", error => {
             this._errorStatus = error;
             this.Trigger(C3.Plugins.wortal.Cnds.ErrorCallback);

--- a/Wortal/c3runtime/wortal-ads.js
+++ b/Wortal/c3runtime/wortal-ads.js
@@ -15,7 +15,13 @@
                 ["wortal-ads", data => this._WortalAds(data)]
             ]);
 
-            this._IsAdBlocked();
+            if (window.Wortal && window.Wortal.isInitialized) {
+                this._IsAdBlocked();
+            } else {
+                window.addEventListener("wortal-sdk-initialized", () => {
+                    this._IsAdBlocked();
+                });
+            }
         }
 
         _WortalAds(data) {

--- a/Wortal/c3runtime/wortal-iap.js
+++ b/Wortal/c3runtime/wortal-iap.js
@@ -19,7 +19,13 @@
 
             // We want to set the expression flag right away because the game might want to change what
             // they present to the player depending on this status. Ex: Don't display shop pop-ups after first load.
-            this._IsEnabled();
+            if (window.Wortal && window.Wortal.isInitialized) {
+                this._IsEnabled();
+            } else {
+                window.addEventListener("wortal-sdk-initialized", () => {
+                    this._IsEnabled();
+                });
+            }
         };
 
         _WortalIAP(data) {

--- a/Wortal/c3runtime/wortal-player.js
+++ b/Wortal/c3runtime/wortal-player.js
@@ -22,13 +22,21 @@
                 ["wortal-player", data => this._WortalPlayer(data)]
             ]);
 
-            // These shouldn't change at runtime, so we can just set them here.
-            setTimeout(() => {
+            const runSetup = () => {
                 this._GetID();
                 this._GetName();
                 this._GetPhoto();
                 this._IsFirstPlay();
-            }, 1000);
+            };
+
+            // These shouldn't change at runtime, so we can just set them here.
+            if (window.Wortal && window.Wortal.isInitialized) {
+                runSetup();
+            } else {
+                window.addEventListener("wortal-sdk-initialized", () => {
+                    runSetup();
+                });
+            }
         };
 
         _WortalPlayer(data) {

--- a/Wortal/c3runtime/wortal-session.js
+++ b/Wortal/c3runtime/wortal-session.js
@@ -16,7 +16,7 @@
                 ["wortal-session", data => this._WortalSession(data)]
             ]);
 
-            setTimeout(() => {
+            const runSetup = () => {
                 this._GetEntryPointData();
                 this._GetLocale();
                 this._GetTrafficSource();
@@ -24,7 +24,15 @@
                 this._GetDevice();
                 this._GetOrientation();
                 window.Wortal.session.onOrientationChange(orientation => this.PostToRuntime("session_on_orientation_change_callback", orientation));
-            }, 1000);
+            };
+
+            if (window.Wortal && window.Wortal.isInitialized) {
+                runSetup();
+            } else {
+                window.addEventListener("wortal-sdk-initialized", () => {
+                    runSetup();
+                });
+            }
         };
 
         _WortalSession(data) {

--- a/Wortal/lang/en-US.json
+++ b/Wortal/lang/en-US.json
@@ -262,6 +262,16 @@
                         "display-text": "Join Callback",
                         "description": "Called when the tournament join promise has resolved."
                     },
+                    "initialize-callback": {
+                        "list-name": "Initialize Callback",
+                        "display-text": "Initialize Callback",
+                        "description": "Called when the SDK has been initialized."
+                    },
+                    "start-game-callback": {
+                        "list-name": "Start Game Callback",
+                        "display-text": "Start Game Callback",
+                        "description": "Called when the game has started."
+                    },
                     "error-callback": {
                         "list-name": "Error Callback",
                         "display-text": "Error Callback",
@@ -975,6 +985,16 @@
                             }
                         }
                     },
+                    "initialize-async": {
+                        "list-name": "Initialize Async",
+                        "display-text": "Initialize Async",
+                        "description": "Initializes the SDK."
+                    },
+                    "start-game-async": {
+                        "list-name": "Start Game Async",
+                        "display-text": "Start Game Async",
+                        "description": "Starts the game."
+                    },
                     "set-loading-progress": {
                         "list-name": "Set Loading Progress",
                         "display-text": "Set Loading Progress {0}",
@@ -1157,6 +1177,10 @@
                     "tournament-created": {
                         "description": "Returns a JSON string with the created tournament.",
                         "translated-name": "Created Tournament"
+                    },
+                    "initialized": {
+                        "description": "Returns whether or not the SDK has been initialized. 0 for false, 1 for true.",
+                        "translated-name": "Initialized"
                     },
                     "error-status": {
                         "description": "Returns a JSON string with the error that was thrown last by the SDK.",


### PR DESCRIPTION
This PR changes the initialization process completely. As of SDK Core v2.0.0 we removed the auto-initialization option to streamline the entry point. This PR removes the auto-init and adds functionality for the developer to manually initialize the SDK.

In addition, modules that called member functions in their constructors were previously using `setTimeout` to delay the calls slightly until the SDK was initialized, which previously was usually a consistent timeframe as we only used auto-init. These calls have now been refactored so they first check if `Wortal.isInitialized` and if not true, listen for the `wortal-sdk-initialized` event to fire before calling. This ensures we don't attempt to access the SDK before it's usable, regardless of when the developer initializes it.